### PR TITLE
Initial Heroku configuration.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,11 @@
+# Uses buildpacks for sbcl and graphviz.
+#
+# > heroku buildpacks:add --index 1 https://github.com/yangby/heroku-buildpack-sbcl.git
+# > heroku buildpacks:add --index 2 https://github.com/weibeld/heroku-buildpack-graphviz.git
+#
+# Buildpack added. Next release on ubercalc will use:
+#  1. https://github.com/yangby/heroku-buildpack-sbcl.git
+#  2. https://github.com/weibeld/heroku-buildpack-graphviz.git
+
+web: $HOME/ubercalc ubercalc web --port $PORT
+

--- a/build.lisp
+++ b/build.lisp
@@ -1,0 +1,5 @@
+(log-title "Building Orient…")
+(push *build-dir* asdf:*central-registry*)
+(ql:quickload :orient)
+(log-footer "Dumping image.")
+(sb-ext:save-lisp-and-die (merge-pathnames "ubercalc" *build-dir*) :toplevel #'cli:main :executable t)

--- a/cli/cli.lisp
+++ b/cli/cli.lisp
@@ -61,11 +61,27 @@
 	      (case command
 		((:web)
 		 (let ((acceptor (if port
-				     (web:start-web :port port)
+				     (web:start-web :port (parse-integer port))
 				     (web:start-web))))
 		   (when acceptor
 		     (format *error-output* "Orient webserver started on port ~S" (hunchentoot:acceptor-port acceptor)))
+		   (handler-case (bt:join-thread (find-if (lambda (th)
+							    (search "hunchentoot" (bt:thread-name th)))
+							  (bt:all-threads)))
+		     ;; https://stackoverflow.com/questions/48103501/deploying-common-lisp-web-applications
+		     ;; Catch a user's C-c
+		     (#+sbcl sb-sys:interactive-interrupt
+		       #+ccl  ccl:interrupt-signal-condition
+		       #+clisp system::simple-interrupt-condition
+		       #+ecl ext:interactive-interrupt
+		       #+allegro excl:interrupt-signal
+		       () (progn
+			    (format *error-output* "Aborting.~&")
+			    (web:stop-web)
+			    (uiop:quit)))
+		     (error (c) (format t "Woops, an unknown error occured:~&~a~&" c)))
 		   (let ((*package* (find-package :orient.web)))
+		     
 		     (sb-impl::toplevel-repl nil))))
 		((:solve)
 		 (cond

--- a/web/web.lisp
+++ b/web/web.lisp
@@ -121,11 +121,11 @@
       `(:html-escape ,(format nil "~S" value))
       `(:html-escape ,(or value "FALSE"))))
 
-;; (defmethod present-data ((format (eql :html)) (null null) (system system) &key)
-;;   "NULL")
+(defmethod present-data ((format (eql :html)) (null null) (system system) &key)
+   "NULL")
 
-;; (defmethod present-data ((format (eql :html)) (thing t) (null null) &key)
-;;   (format-value format thing))
+(defmethod present-data ((format (eql :html)) (thing t) (null null) &key)
+  (format-value format thing))
 
 (defmethod present-data ((format (eql :html)) (tuple wb-map) (system system) &key alt-bgcolor use-alt)
   (cons
@@ -237,7 +237,8 @@
 (defun serve-graph (plan tmp-name &key (layout "dot") (format "svg") base-url)
   ;; FIXME: There must be a better way.
   ;; Or maybe this is good, and we should cache (based on content).
-  (let ((image-file (make-pathname :directory "tmp" :name tmp-name :type format)))
+  (let ((image-file (ensure-directories-exist (merge-pathnames (make-pathname :name tmp-name :type format)
+							       (uiop:default-temporary-directory)))))
     (orient::dot
      (orient::dot-format
       (generate-directed-graph plan) :base-url base-url)
@@ -248,7 +249,7 @@
  
 (define-calculation-pages (economic-performance :uri "/filecoin/economic-performance"
 						:title "Filecoin Economic Performance Requirements"
-						:vars (seal-cost fgr-months total-up-front-cost up-front-compute-cost
+						:vars (gib-seal-cost gib-hour-seal-investment fgr-months total-up-front-cost up-front-compute-cost
 								 one-year-fgr two-year-fgr three-year-fgr)
 						:override-parameters (GiB-seal-cycles)
 						:system (performance-system :isolated t))
@@ -299,10 +300,11 @@
 
 (define-calculation-pages (filecoin :uri "/filecoin"
 				    :title "Filecoin Writ Large"
-				    :vars (seal-cost seal-time fgr-months total-up-front-cost fc::filecoin-requirements-satisfied
-						     one-year-fgr two-year-fgr three-year-fgr
+				    :vars (gib-seal-cost gib-hour-seal-investment seal-time fgr-months total-up-front-cost
+							 fc::filecoin-requirements-satisfied
+							 one-year-fgr two-year-fgr three-year-fgr
 					;storage-to-proof-size-float
-						     )
+							 )
 				    :override-parameters (annual-income layers total-challenges sector-size)
 				    :system (filecoin-system))
     ((annual-income :parameter-type 'integer)


### PR DESCRIPTION
TODO: graph generation currently encounters error while trying to create a file in /tmp.

---
Load with ASDF not Quicklisp.

Add home dir to central registry.

Load orient.asdf then quickload.

Add *build-dir* to asdf:*central-registry*.

Don't require web.

Quickload when launching.

Use build dir when launching.

Use load dir when launching.

Use load directory, not filename.

Try dumping image to avoid startup timeout.

Run ubercalc with web.

Don't escape quotation marks in source.

Provide absolute path to ubercalc in Procfile.

Try to dump image into build dir.

Add dummy executable name argument.

Use flag when passing port.

Parse port before using.

Join webserver thread to foreground.

Fix web calcs broken by parameter-name changes.

Use \$HOME rather than hard-coded directory. Use graphviz buildpack.

Document multiple buildpack setup.

Ensure /tmp directory exists.

Use uiop:default-temporary-directory instead of /tmp.