### PR TITLE
Heroku

### DIFF
--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -675,11 +675,12 @@
     (make-relation tuples)))
 
 (defun generate-directed-graph (plan)
-  (loop for transformation in plan
-     for signature = (transformation-signature transformation)
-     append (loop for dependency in (convert 'list (signature-input signature))
-	       append (loop for target in (convert 'list (signature-output signature))
-			 collect (list dependency target)))))
+  (remove-duplicates (loop for transformation in plan
+			for signature = (transformation-signature transformation)
+			append (loop for dependency in (convert 'list (signature-input signature))
+				  append (loop for target in (convert 'list (signature-output signature))
+					    collect (list dependency target))))
+		     :test #'equal))
 
 (defun write-dot-format (directed-graph stream &key base-url)
   (flet ((make-label (symbol &key url target)
@@ -699,7 +700,7 @@
     (write-dot-format directed-graph out :base-url base-url)))
 
 (defun dot (dot-format &key format output-file (layout "dot"))
-  (uiop:run-program (format nil "touch ~A" output-file))
+  (uiop:run-program (format nil "echo ' ' > ~A" output-file))
   (with-input-from-string (in dot-format)
     (uiop:run-program (format nil "dot -K~A -T ~A" layout format) :output output-file :input in)))
 

--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -699,13 +699,11 @@
   (with-output-to-string (out)
     (write-dot-format directed-graph out :base-url base-url)))
 
-(defvar *dot-path* "/usr/local/bin/dot")
-
 (defun dot (dot-format &key format output-file (layout "dot"))
   (with-input-from-string (in dot-format)
     ;; UIOP:RUN-PROGRAM seems to fail with error that file does not exist when we try this on Heroku. Not sure if a linux or Heroku thing or what.
     #+sbcl
-    (sb-ext:run-program *dot-path* (list (format nil "-K~A" layout) "-T" format) :output output-file :input in :if-output-exists :supersede)
+    (sb-ext:run-program "/bin/sh" (list "-c" (format nil "dot -K~A -T ~A" layout format)) :output output-file :input in :if-output-exists :supersede)
     #-sbcl
     (uiop:run-program (format nil "dot -K~A -T ~A" layout format) :output output-file :input in)))
 

--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -699,6 +699,7 @@
     (write-dot-format directed-graph out :base-url base-url)))
 
 (defun dot (dot-format &key format output-file (layout "dot"))
+  (uiop:run-program (format nil "touch ~A" output-file))
   (with-input-from-string (in dot-format)
     (uiop:run-program (format nil "dot -K~A -T ~A" layout format) :output output-file :input in)))
 

--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -699,9 +699,14 @@
   (with-output-to-string (out)
     (write-dot-format directed-graph out :base-url base-url)))
 
+(defvar *dot-path* "/usr/local/bin/dot")
+
 (defun dot (dot-format &key format output-file (layout "dot"))
-  (uiop:run-program (format nil "echo ' ' > ~A" output-file))
   (with-input-from-string (in dot-format)
+    ;; UIOP:RUN-PROGRAM seems to fail with error that file does not exist when we try this on Heroku. Not sure if a linux or Heroku thing or what.
+    #+sbcl
+    (sb-ext:run-program *dot-path* (list (format nil "-K~A" layout) "-T" format) :output output-file :input in :if-output-exists :supersede)
+    #-sbcl
     (uiop:run-program (format nil "dot -K~A -T ~A" layout format) :output output-file :input in)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Remove duplicates so we don't sometimes get double edges in graph.

Route around `uiop:run-program` linux(?) problem with `sb-ext:run-program` and `/bin/sh`.