### PR TITLE
Allow passing project root from CLI and do so on Heroku.

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -7,5 +7,5 @@
 #  1. https://github.com/yangby/heroku-buildpack-sbcl.git
 #  2. https://github.com/weibeld/heroku-buildpack-graphviz.git
 
-web: $HOME/ubercalc ubercalc web --port $PORT
+web: $HOME/ubercalc ubercalc web -r . --port $PORT
 

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -2,7 +2,7 @@
   (:use :common-lisp)
   (:nicknames :util)
   (:export :comma-list :keywordize :map-tree :transform-tree :transform-tree-if :string-split :project-commit :project-merge :project-sha1
-	   :project-root))
+	   :project-root :*project-root*))
 
 (defpackage :orient
   (:use :common-lisp :it.bese.FiveAm :fset :gmap :orient.base.util)

--- a/base/util.lisp
+++ b/base/util.lisp
@@ -32,11 +32,14 @@
 
 (defun commit-base-uri (&optional (base-uri *project-base-uri*))
   (format nil "~A/commit" base-uri))
-  
+
+(defvar *project-root* nil "The project root should be a directory pathname and will override the calculated value of PROJECT-ROOT if set.")
+
 (defun project-root ()
-  (let* ((root-file (asdf:system-source-file (asdf:find-system :orient)))
-	 (project-dir (pathname-directory root-file)))
-    (make-pathname :directory project-dir)))
+  (or *project-root*
+      (let* ((root-file (asdf:system-source-file (asdf:find-system :orient)))
+	     (project-dir (pathname-directory root-file)))
+	(make-pathname :directory project-dir))))
 
 (defun project-merge (pathspec)
   (merge-pathnames (pathname pathspec) (project-root)))

--- a/cli/cli.lisp
+++ b/cli/cli.lisp
@@ -30,15 +30,20 @@
 		   (port (port "port-number" "port to listen on"))
 		   (merge (merge nil "merge inputs with (instead of replacing) defaults"))
 		   (command (command "{dump, solve, test, web}" "<COMMAND>: may be provided as free token (without flag)."))
+		   (root (root "project root, so we can find json files"))
 		   &free commands)
     (map-parsed-options (cli-options) nil '("in" "i"
 					    "out" "o"
 					    "calc" "c"
 					    "port" "p"
 					    "command" "c"
-					    "merge" "m") ;; Need to include all parameters from WITH-CLI-OPTIONS here.
+					    "merge" "m"
+					    "root" "r") ;; Need to include all parameters from WITH-CLI-OPTIONS here.
 			(lambda (option value) (declare (ignore option value)))
 			(lambda (free-val) (declare (ignore free-val))))
+    (when root
+      (setq orient.base.util:*project-root* (truename root)))
+    
     (destructuring-bind (&optional arg0 free-command &rest subcommands) commands
       (declare (ignore arg0 subcommands))
       (let ((command (keywordize (if command

--- a/filecoin/base.lisp
+++ b/filecoin/base.lisp
@@ -46,7 +46,7 @@
    (node-bytes 32)
    (sector-GiB 32)))
 
-(defparameter *filecoin-json-directory* (project-merge "filecoin/json/"))
+(defun filecoin-json-directory () (project-merge "filecoin/json/"))
 
   
 

--- a/filecoin/import.lisp
+++ b/filecoin/import.lisp
@@ -2,12 +2,12 @@
 
 (in-suite filecoin-suite)
 
-(defparameter *filecoin-json-path* (merge-pathnames *filecoin-json-directory* "filecoin.json"))
+(defun filecoin-json-path () (merge-pathnames (filecoin-json-directory) "filecoin.json"))
 
 (defvar *benchmarks* nil)
 
 (defun benchmarks-pathname ()
-  (let* ((candidates (directory (merge-pathnames (make-pathname :directory '(:relative "input") :name :wild :type "json") *filecoin-json-directory*)))
+  (let* ((candidates (directory (merge-pathnames (make-pathname :directory '(:relative "input") :name :wild :type "json") (filecoin-json-directory))))
 	 (narrowed (remove-if-not (lambda (pathname)
 				    (let* ((name (pathname-name pathname))					  
 					   (suffix "-benchmarks")
@@ -67,7 +67,7 @@
 				      hash-constraints)))))
 
 (defun benchmarks (&optional (pathname (benchmarks-pathname)))
-  (or ;*benchmarks*
+  (or *benchmarks*
       (let ((data (read-benchmarks pathname)))
 	(setq *benchmarks*
 	      (tuple

--- a/filecoin/publish.lisp
+++ b/filecoin/publish.lisp
@@ -19,7 +19,7 @@
       (setf assignments (extract assignments :error t)))
     published))
 
-(defun publish-filecoin-json (&optional (where *filecoin-json-path*))
+(defun publish-filecoin-json (&optional (where (filecoin-json-path)))
   (typecase where
     ((or string pathname)
      (let* ((pathname (project-merge where))


### PR DESCRIPTION
This fixes an error on Heroku when trying to access values derived from input JSON. The problem was that the project path was being set at build time, but the server is launched from a different directory. The fix is to pass the current directory as an argument when starting the server.