### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
-test: utest
+.PHONY: always
+
+test : utest
 # Tests from command-line are failing due to some floating-point equality issue, apparently running with different precision than expected.
 # So we'll just dump an image and run tests with that, since this avoids the problem. The added overhead is a drag, but it's not bad.
 
-docker:
+docker :
 	docker build . -t ubercalc
 
-ubercalc:
+ubercalc : always
 	cl -Q -sp orient --dump bin/ubercalc
 
-utest: ubercalc
+utest : ubercalc
 	./bin/ucalc test
 
-dtest: docker
+dtest : docker
 	./bin/dcalc test

--- a/Procfile
+++ b/Procfile
@@ -7,5 +7,5 @@
 #  1. https://github.com/yangby/heroku-buildpack-sbcl.git
 #  2. https://github.com/weibeld/heroku-buildpack-graphviz.git
 
-web: $HOME/ubercalc ubercalc web -r . --port $PORT
+web: $HOME/ubercalc ubercalc-launcher web -r . --port $PORT
 

--- a/build.lisp
+++ b/build.lisp
@@ -2,4 +2,4 @@
 (push *build-dir* asdf:*central-registry*)
 (ql:quickload :orient)
 (log-footer "Dumping image.")
-(sb-ext:save-lisp-and-die (merge-pathnames "ubercalc" *build-dir*) :toplevel #'cli:main :executable t)
+(sb-ext:save-lisp-and-die (merge-pathnames "ubercalc-launcher" *build-dir*) :toplevel #'cli:main :executable t)


### PR DESCRIPTION
This PR fixes issues created by the introduction of an ubercalc directory in an earlier commit.

This caused two conflicts:
- ubercalc was being used as the name of the build artifact produced and run on Heroku.
  Fix: rename to ubercalc-web-launcher
- ubercalc was a make target
  Fix: use a phony target as dependency.
