### PR TITLE
Support unwrapping of nested constraints.

### DIFF
--- a/filecoin/zigzag.lisp
+++ b/filecoin/zigzag.lisp
@@ -181,14 +181,12 @@
 
 (test select-hash-function-tuple
   (let* ((data (tuple (hf-name :pedersen) (hash-functions (hash-functions))))
-	 (expected (with
-		    (with data 'constraints 1376)
-		    'hf (extract (join (tuple (hash-function-name :pedersen)) (hash-functions)))))
+	 (expected (with data
+			 'hf (extract (join (tuple (hash-function-name :pedersen)) (hash-functions)))))
 	 (system (constraint-system
 		  ((hf (select-hash-function-tuple hf-name hash-functions))
 		   (constraints (tref 'hash-function-constraints hf))))))
-    (is (same expected
-	      (solve-for system '() data)))))
+    (is (same expected (solve-for system '() data)))))
 
 ;; TODO: With the right abstraction, this would be much simpler. Think about it.
 (define-system-constraint select-hash-function


### PR DESCRIPTION
Support for unwrapping constraint definitions. This works transparently, expanding like so:
```
ORIENT> (unwrap-constraint-definitions '((layers (+ (+ (* 2 (log (/ 1 (* 3 (- epsilon (* 2 delta)))) 2))
                               (* 2 (/ (- 0.8 (+ epsilon delta))
                                   (- 0.12 (* 2 delta)))))
                          2))))


((TMP7% (* 2 DELTA))
 (TMP6% (- EPSILON TMP7%))
 (TMP5% (* 3 TMP6%))
 (TMP4% (/ 1 TMP5%))
 (TMP3% (LOG TMP4% 2))
 (TMP2% (* 2 TMP3%))
 (TMP11% (+ EPSILON DELTA))
 (TMP10% (- 0.8 TMP11%))
 (TMP13% (* 2 DELTA))
 (TMP12% (- 0.12 TMP13%))
 (TMP9% (/ TMP10% TMP12%))
 (TMP8% (* 2 TMP9%))
 (TMP1% (+ TMP2% TMP8%))
 (LAYERS (+ TMP1% 2)))
```