### PR TITLE
Add orient-lang CLI support, including graphs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.fasl
 *~
 scratch
-bin/ubercalc
+bin/orient.image

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ COPY . /root/orient
 
 RUN ln -s /root/orient/orient.asd /root/quicklisp/local-projects/orient.asd
 
-# RUN cd /root/orient/bin && cl -Q -sp orient --dump /root/ubercalc
+# RUN cd /root/orient/bin && cl -Q -sp orient --dump /root/orient
 # We should be able to use `cl --dump`, but for some reason it's not working in the container.
 
-RUN cl -Q -sp orient -x "(progn (push :docker *features*) (sb-ext:save-lisp-and-die \"/root/ubercalc\" :toplevel #'cli:main :executable t))"
+RUN cl -Q -sp orient -x "(progn (push :docker *features*) (sb-ext:save-lisp-and-die \"/root/orient.image\" :toplevel #'cli:main :executable t))"
 
-ENTRYPOINT ["/root/ubercalc"]
+ENTRYPOINT ["/root/orient.image"]

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ test : utest
 # So we'll just dump an image and run tests with that, since this avoids the problem. The added overhead is a drag, but it's not bad.
 
 docker :
-	docker build . -t ubercalc
+	docker build . -t orient
 
-ubercalc : always
-	cl -Q -sp orient --dump bin/ubercalc
+image : always
+	cl -Q -sp orient --dump bin/orient.image
 
-utest : ubercalc
-	./bin/ucalc test
+utest : image
+	./bin/orient test
 
 dtest : docker
 	./bin/dcalc test

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ Now you can run the CLI and source changes will be immediately reflected, but st
 If you just want to *use* the CLI, first dump an image:
 
 ```bash
-> make ubercalc
+> make image
 ```
 
 Now startup should be very fast:
 
 ```bash
-> ./bin/ucalc ... <args>
+> ./bin/orient ... <args>
 ```
 
 ### Docker

--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -664,8 +664,8 @@
     (when solution
       (project output solution))))
 
-(defun plan-for (system output &optional initial-data)
-  (let* ((defaulted (defaulted-initial-data system initial-data))
+(defun plan-for (system output &optional initial-data &key override-data)
+  (let* ((defaulted (defaulted-initial-data system initial-data :override-data override-data))
 	 (sig (make-signature (and defaulted (attributes defaulted)) output)))
     (plan system sig)))
 

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -2,6 +2,7 @@
   (:use :common-lisp)
   (:nicknames :util)
   (:export :comma-list
+	   :get-string
 	   :keywordize
 	   :map-tree
 	   :partial

--- a/bin/dcalc
+++ b/bin/dcalc
@@ -1,1 +1,1 @@
-docker run ubercalc dcalc $@
+docker run orient dcalc $@

--- a/bin/odev
+++ b/bin/odev
@@ -1,0 +1,1 @@
+#!/usr/local/bin/cl -Q -sp orient -E 'cli:main' --

--- a/bin/orient
+++ b/bin/orient
@@ -1,1 +1,3 @@
-#!/usr/local/bin/cl -Q -sp orient -E 'cli:main' --
+/usr/local/bin/cl -m $(dirname $0)/orient.image -p cli -E main -- $0 $@
+
+

--- a/bin/ucalc
+++ b/bin/ucalc
@@ -1,3 +1,0 @@
-/usr/local/bin/cl -m $(dirname $0)/ubercalc -p cli -E main -- $0 $@
-
-

--- a/orient.asd
+++ b/orient.asd
@@ -14,8 +14,8 @@
 			 (:file "relation")
 			 (:file "orient")
 			 (:file "constraint")
-			 (:file "syntax")
 			 (:file "interface")
+			 (:file "syntax")
 			 (:file "presentation"))			
 			:perform (test-op (o c) (symbol-call :fiveam :run! (find-symbol "ORIENT-SUITE" "ORIENT"))))
 	       (:module "filecoin"


### PR DESCRIPTION
Initial support for CLI using orient-lang syntax.

Artifacts and make targets have been refactored, so the primary CLI command is now `orient`.

CLI access to Filecoin-specific calculators has been removed (though they are still accessible through the web interface).

Adds support for `orient graph`, which generates graphviz.