### PR TITLE
Cli report

### DIFF
--- a/base/constraint.lisp
+++ b/base/constraint.lisp
@@ -59,6 +59,10 @@
 (defun new-target (prefix)
   (intern (format nil "~A.TMP~D%" prefix (incf *new-definition-count*))))
 
+(defun tmp-p (symbol)
+  (let ((name (symbol-name symbol)))
+    (char= #\% (char name (1- (length name))))))
+
 (defun emit-new-definition (def)
   (push def *new-definitions*))
 

--- a/base/orient.lisp
+++ b/base/orient.lisp
@@ -565,6 +565,7 @@
 		 (reduce-result (reduce reducer plan :initial-value (list initial-value '()))))
 	    (destructuring-bind (result report-results) reduce-result
 	      (values result plan (synthesize-report-steps report report-results) initial-value)))
+	  
 	  (values nil plan nil initial-value)))))
 
 (defun make-pipeline-reducer (system &key report)
@@ -643,7 +644,7 @@
 		  solution)
 	      plan report defaulted-data))))
 
-(defun report-solution-for (output &key (system *current-construction*) initial-data (format t) override-data project-solution return-plan return-defaulted-data)
+(defun report-solution-for (output &key system initial-data (format t) override-data project-solution return-plan return-defaulted-data)
   (multiple-value-bind (solution plan report defaulted-data) (solve-for system output initial-data
 									:report format
 									:override-data override-data
@@ -678,7 +679,9 @@
 			     base))))
     (make-relation tuples)))
 
-
+(defun clean-tmps (attributed)
+  (project (filter #'tmp-p (attributes attributed)) attributed :invert t))
+  
 (defstruct plan-graph (edges))
 
 (defmethod cl-dot:graph-object-node ((graph plan-graph) attribute)

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -3,6 +3,7 @@
   (:nicknames :util)
   (:export :comma-list
 	   :get-string
+	   :resolve-json-input
 	   :keywordize
 	   :map-tree
 	   :partial
@@ -32,6 +33,7 @@
   (:export
 
    :all-system-schemas :assignments
+   :clean-tmps
    :dbg :display :aif :apply-transformation :ask :attributes :awhen
    :dbreak :*dval*
    :cardinality


### PR DESCRIPTION
Adds HTML report to CLI and adds support for input via HTTP(S) URI:

Usage:
```
> bin/orient report --system=https://gist.githubusercontent.com/nicola/90f8e37648043118721dc8c4e9fb8542/raw/3404bf480084461ddec403ca32ffc0438fbcc283/porcu.orient --in=https://gist.githubusercontent.com/nicola/90f8e37648043118721dc8c4e9fb8542/raw/3605cb4a1a46e2510eac4de7b496e926a5764a58/params.json > ~/tmp/report.html | bcat
```