### PR TITLE
System server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 image: bin/orient.image
 
-bin/orient.image : $(shell find . | grep .lisp)
+bin/orient.image : $(shell find . -type f -name '*.lisp') $(shell find . -type f -name '*.asd')
 	cl -Q -sp orient --dump bin/orient.image
 
 test : utest

--- a/base/interface.lisp
+++ b/base/interface.lisp
@@ -308,7 +308,7 @@
 (defun dump-json (spec thing stream &key expand-references)
   (declare (ignore spec))
   (let ((json:*lisp-identifier-name-to-json* #'lisp-to-snake-case)
-	(to-use (if expand-references
+	(to-use (if (and expand-references thing)
 		    (expand-references thing)
 		    thing)))
     (encode-json to-use stream)

--- a/orient.asd
+++ b/orient.asd
@@ -36,7 +36,8 @@
 			:serial t
 			:components
 			((:file "html")
-			 (:file "web")))
+			 (:file "web")
+                         (:file "api")))
 	       (:module "cli"
 			:depends-on ("base" "filecoin")
 			:serial t

--- a/orient.asd
+++ b/orient.asd
@@ -16,7 +16,7 @@
 			 (:file "constraint")
 			 (:file "interface")
 			 (:file "lang")
-			 (:file "presentation"))			
+			 (:file "presentation"))
 			:perform (test-op (o c) (symbol-call :fiveam :run! (find-symbol "ORIENT-SUITE" "ORIENT"))))
 	       (:module "filecoin"
 			:depends-on ("base")
@@ -41,8 +41,7 @@
 			:depends-on ("base" "filecoin")
 			:serial t
 			:components
-			((:file "cli")))
-	       )
+			((:file "cli"))))
   :in-order-to ((test-op (load-op "orient")))
   :perform (test-op (o c)
 		    (flet ((run-suite (name-spec package-spec)
@@ -52,9 +51,9 @@
 			    (orient (run-suite :orient-suite :orient))
 			    (interface (run-suite :interface-suite :orient.interface))
 			    (orient-lang (run-suite :orient-lang-suite :orient.lang))
-			    (filecoin (run-suite :filecoin-suite :filecoin))			    
+			    (filecoin (run-suite :filecoin-suite :filecoin))
 			    (web (run-suite :web-suite :orient.web)))
-			(unless (and orient-relation orient-constraint orient interface filecoin web)
+			(unless (and orient-relation orient-constraint orient interface orient-lang filecoin web)
 			  (error "Some tests failed.")
 			  ;; TODO: report which suites failed.
 			  )))))

--- a/web/api.lisp
+++ b/web/api.lisp
@@ -1,0 +1,28 @@
+(defpackage orient.web.api
+    (:use :common-lisp :orient :filecoin :orient.web.html :orient.base.util :it.bese.FiveAm :orient.web :orient.interface)
+    (:shadowing-import-from :fset :reduce  :union)
+    (:export :register-primary-solver-endpoint)
+    (:nicknames :api))
+
+(in-package :orient.web.api)
+(def-suite api-suite)
+(in-suite api-suite)
+
+(defvar *system-endpoints* '())
+
+(defvar *system-endpoint-base-uri* "/system/")
+
+(defun system-endpoint (name)
+  (concatenate 'string *system-endpoint-base-uri* name))
+
+(defun random-endpoint ()
+  (let ((rand (hunchentoot::create-random-string 10)))
+    (system-endpoint rand)))
+
+(defvar *solution-endpoint* "/solve")
+
+(defun register-primary-solver-endpoint (callback &key merge)
+  (hunchentoot:define-easy-handler (solve-primary-system :uri *solution-endpoint*) ()
+    (when (boundp '*acceptor*) (setf (hunchentoot:content-type*) "text/html"))
+    (let* ((raw-data (hunchentoot:raw-post-data :force-text t)))
+      (funcall callback raw-data))))

--- a/web/web.lisp
+++ b/web/web.lisp
@@ -3,7 +3,7 @@
   (:import-from :fset :wb-map :image :filter :contains? :convert)
   (:shadowing-import-from :fset :reduce  :union)
   (:nicknames :web)
-  (:export :serve-report-page :start-web :stop-web :report-page-for))
+  (:export :serve-report-page :start-web :stop-web :report-page-for *orient-web-port* *acceptor*))
 
 (in-package :orient.web)
 (def-suite web-suite)


### PR DESCRIPTION
Add support for a default system specified at CLI when starting webserver (default port 8888). If system is supplied and successfully loaded, you can POST to it at `/solve`. You can POST repeatedly with new data and receive new solutions to the original system as long as the server is running.

Example using `filecoin-project/specs`:

Start the server (from `specs/src/orient`):
```
(base) ➜  orient git:(master) ✗ ../../orient/bin/orient web --system=filecoin.orient
```

Then, at another shell (also in `specs/src/orient`):
```
(base) ➜  orient git:(master) ✗ curl -d @filecoin.json -X POST localhost:8888/solve | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3165  100  2544  100   621  97846  23884 --:--:-- --:--:-- --:--:--  118k
[
  {
    "actor_method": 8,
    "actors_messages_fraction": 0.30000004,
    "actors_messages_per_block": 32.661842,
    "address_size": 35,
    "all_post_messages_per_year": 122557560,
    "all_post_messages_per_year.tmp1%": 122557560000,
    "all_seal_messages_per_year": 335544320,
    "all_seal_size_per_year": 335544320,
    "avg_posts_messages_per_block": 11.650845,
    "avg_proofs_messages_per_block": 43.549118,
    "avg_seals_messages_per_block": 31.898273,
    "avg_tickets": 1,
    "block_time": 15,
    "blocks_in_a_year": 10519200,
    "blocks_in_a_year.tmp4%": 2103840,
    "blocks_in_ten_years": 105192000,
    "cid_size": 35,
    "cid_size.tmp1%": 33,
    "cid_size.tmp2%": 34,
    "cores": 16,
    "degree": 14,
    "degree_base": 6,
    "degree_expander": 8,
    "eix": 1152921504606847000,
    "encoding_amax": 2,
    "encoding_time.tmp1%": 14,
    "encoding_time.tmp2%": 1,
    "exit_code": 4,
    "expected_winning_miners": 5,
    "from_address": 35,
    "gas_limit": 8,
    "gas_price": 8,
    "gas_used": 8,
    "gib": 1073741824,
    "kdf_content": 15,
    "kdf_hash_size": 32,
    "kdf_hash_time": 4.5608e-08,
    "kib": 1024,
    "lambda": 10,
    "leaf_hash_circuit_time": 0.076994,
    "leaf_hash_constraints": 1300,
    "leaf_hash_time": 4.5608e-08,
    "max_tickets": 19.07985,
    "max_tickets.tmp1%": 18.07985,
    "max_tickets.tmp2%": -18.471298,
    "max_tickets.tmp3%": -1.0216511,
    "merkle_hash_constraints": 1300,
    "merkle_hash_time": 1.3078e-05,
    "merkle_hash_time_circuit": 0.076994,
    "message_nonce": 4,
    "message_receipt": 16,
    "message_receipt.tmp1%": 8,
    "message_receipts_cid": 35,
    "message_size": 106,
    "message_size.tmp1%": 70,
    "message_size.tmp2%": 74,
    "message_size.tmp3%": 82,
    "message_size.tmp4%": 90,
    "message_size.tmp5%": 98,
    "messages": 108.872795,
    "messages_root_cid": 35,
    "messages_size": 11540.517,
    "messages.tmp1%": 76.21095,
    "mib": 1048576,
    "min_tickets": 0,
    "miners": 1000,
    "node_size": 32,
    "nodes": 1073741824,
    "one_block_in_ten_years": 9.506427e-09,
    "pib": 1125899906842624,
    "post_challenge_blocks": 480,
    "post_challenge_hours": 2,
    "post_challenge_time": 7200,
    "post_challenge_time.tmp1%": 120,
    "posts_per_sector_per_year": 365.25,
    "proof_messages_fraction": 0.4,
    "proving_period_hours": 24,
    "proving_period_seconds": 86400,
    "proving_period_seconds.tmp1%": 1440,
    "receipts": 108.872795,
    "receipts_size": 1741.9647,
    "reseal": 0,
    "return": 4,
    "rsa_element": 256,
    "seals_per_sector_per_year": 1,
    "sector_size": 34359738368,
    "sector_size_gib": 32,
    "sectors_count": 335544320,
    "snark_max_constraints": 100000000,
    "snark_single_proof_size": 192,
    "spacegap": 0.1,
    "storage_network_capacity": 11529215046068470000,
    "tib": 1099511627776,
    "tickets": 1,
    "to_address": 35,
    "tx_messages_fraction": 0.3,
    "tx_messages_per_block": 32.66184,
    "u64": 8,
    "value": 8,
    "varint": 4,
    "year_in_seconds": 31557600,
    "year_in_seconds.tmp1%": 8766,
    "year_in_seconds.tmp2%": 525960
  }
]
```