### PR TITLE
Add solve-many CLI option.

### DIFF
--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -80,6 +80,7 @@
   (:export :camel-case-to-lisp* :get-json :get-json-data :get-json-data-from-string :get-json-from-string :get-json-relation-list 
            :get-json-relation-list-from-string :dump-json :dump-json-to-string
 	   :load-pipeline :load-transformation :load-tuple :load-json :<-json
+           :make-relation-list
 	   :test-roundtrip :with-json-encoding
 	   :*alpha-sort-tuples* :*schema-package*)
   (:nicknames :interface))


### PR DESCRIPTION
This adds a new CLI command `solve-many`. Input *must* be an array. Each element of the array will be processed exactly as top-level input to `solve` would be, and the results are gathered into a top-level array in the output.