### PR TITLE
Add Disk cache

### DIFF
--- a/base/cache.lisp
+++ b/base/cache.lisp
@@ -15,19 +15,39 @@
   ((mem-cache :initarg :mem-cache :initform (make-instance 'mem-cache) :accessor cache-mem-cache)
    (disk-cache :initarg :disk-cache :initform (make-instance 'disk-cache) :accessor cache-disk-cache)))
 
-(defgeneric cache-lookup (key cache)
-  (:method ((key t) (cache mem-cache))
+(defun make-disk-backed-mem-cache (&key (root *cache-dir*))
+  (make-instance 'disk-backed-mem-cache :disk-cache (make-instance 'disk-cache :root root)))
+
+(defgeneric cache-lookup (key cache &key payload-deserializer)
+  (:method ((key t) (cache mem-cache)  &key &allow-other-keys)
     (gethash key (cache-hash-table cache)))
-  (:method ((key t) (cache disk-cache))
+  (:method ((key t) (cache disk-cache)  &key payload-deserializer &allow-other-keys)
     (let ((pathname (cache-path-for-key cache key)))
       (if (probe-file pathname)
-          (values (load-json :data pathname) t)
-          (values nil nil)))))
+          (let ((raw-values (load-json :data pathname)))
+            (aif payload-deserializer
+                 (values (funcall it raw-values) t)
+                 (values raw-values t)))
+          (values nil nil))))
+  (:method ((key t) (cache disk-backed-mem-cache) &key payload-deserializer)
+    (multiple-value-bind (values mem-presentp)
+        (cache-lookup key (cache-mem-cache cache))
+      (if mem-presentp
+          (values values t)
+          (multiple-value-bind (values disk-presentp)
+              (cache-lookup key (cache-disk-cache cache)
+                            :payload-deserializer payload-deserializer)
+            (if disk-presentp
+                (progn
+                  (cache-store key (cache-mem-cache cache) values)
+                  (values values t))
+                (values nil nil)))))))
 
-(defgeneric cache-store (key cache value)
-  (:method ((key t) (cache mem-cache) (value t))
-    (setf (gethash key (cache-hash-table cache)) value))
-  (:method ((key t) (cache disk-cache) (value t))
+;; Returns VALUES as values.
+(defgeneric cache-store (key cache values &key payload-serializer)
+  (:method ((key t) (cache mem-cache) (values list) &key &allow-other-keys)
+    (setf (gethash key (cache-hash-table cache)) values))
+  (:method ((key t) (cache disk-cache) (values list) &key payload-serializer)
     (let ((pathname (cache-path-for-key cache key)))
       (ensure-directories-exist pathname)
       (with-open-file (out pathname
@@ -36,24 +56,34 @@
                            :if-does-not-exist :create)
         (let ((interface:*schema-package* (find-package 'orient.lang))
               (json:*lisp-identifier-name-to-json* #'string-downcase))
-          (json:encode-json value out))))))
+          (json:with-array (out)
+            (dolist (value (aif payload-serializer
+                                (funcall it values)
+                                values))
+              (cl-json:encode-array-member value out)))
+          (values-list values)))))
+  (:method ((key t) (cache disk-backed-mem-cache) (values list) &key payload-serializer)
+    (cache-store key (cache-disk-cache cache) values :payload-serializer payload-serializer)
+    (cache-store key (cache-mem-cache cache) values :payload-serializer payload-serializer)))
 
 (defgeneric cache-path-for-key (cache key)
   (:method ((cache disk-cache) (key t))
     (make-pathname :directory (cache-root cache)
-                   :name (write-to-string key))))
+                   :name (princ-to-string key))))
 
-;; Collisions are not impossible. SXHASH output is 62 bits. (But this is fast.)
-;; TODO: handle collisions with fallback to collision-resistant hash. (And only then pay that cost.)
 (defun key-for (args)
-  (sxhash args))
+  (let ((args-string (write-to-string args)))
+    (ironclad:byte-array-to-hex-string
+     (ironclad:digest-sequence
+      :sha256
+      (ironclad:ascii-string-to-byte-array args-string)))))
 
-(defun call-with-cache (cache function key-args all-args)
+(defun call-with-cache (cache function key-args all-args &key values-serializer values-deserializer)
   (let* ((key (key-for key-args)))
     (multiple-value-bind (cached-values presentp)
-        (cache-lookup key cache)
+        (cache-lookup key cache :payload-deserializer values-deserializer)
       (if presentp
           (values-list cached-values)
           (let ((values (multiple-value-list (apply function all-args))))
-            (cache-store key cache values)
+            (cache-store key cache values :payload-serializer values-serializer)
             (values-list values))))))

--- a/base/cache.lisp
+++ b/base/cache.lisp
@@ -1,0 +1,39 @@
+(in-package orient.cache)
+
+(defvar *cache-dir* "/tmp/orient-cache/")
+
+(defclass cache () ())
+
+(defclass mem-cache (cache)
+  ;; TODO: limit size.
+  ((hash-table :initarg :hash-table :initform (make-hash-table :test #'equal) :accessor cache-hash-table)))
+
+(defclass disk-cache (cache)
+  ((root :initarg :root :initform *cache-dir* :reader disk-cache-root :accessor cache-root)))
+
+(defclass disk-backed-mem-cache (cache)
+  ((mem-cache :initarg :mem-cache :initform (make-instance 'mem-cache) :accessor cache-mem-cache)
+   (disk-cache :initarg :disk-cache :initform (make-instance 'disk-cache) :accessor cache-disk-cache)))
+
+(defgeneric cache-lookup (key cache)
+  (:method ((key t) (cache mem-cache))
+    (gethash key (cache-hash-table cache))))
+
+(defgeneric cache-store (key cache value)
+  (:method ((key t) (cache mem-cache) (value t))
+    (setf (gethash key (cache-hash-table cache)) value)))
+
+;; Collisions are not impossible. SXHASH output is 62 bits. (But this is fast.)
+;; TODO: handle collisions with fallback to collision-resistant hash. (And only then pay that cost.)
+(defun key-for (args)
+  (sxhash args))
+
+(defun call-with-cache (cache function key-args all-args)
+  (let* ((key (key-for key-args)))
+    (multiple-value-bind (cached-values presentp)
+        (cache-lookup key cache)
+      (if presentp
+          (values-list cached-values)
+          (let ((values (multiple-value-list (apply function all-args))))
+            (cache-store key cache values)
+            (values-list values))))))

--- a/base/interface.lisp
+++ b/base/interface.lisp
@@ -2,7 +2,7 @@
 (def-suite interface-suite)
 (in-suite interface-suite)
 
-(defvar *schema-package*)
+(defvar *schema-package* (find-package :orient.lang))
 
 (defun effective-schema-package ()
   (or (and (boundp '*schema-package*)

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -89,7 +89,8 @@
 
 (defpackage orient.cache
   (:use :common-lisp :orient :orient.interface :it.bese.FiveAm :orient.base.util)
-  (:export :cache :disk-cache :mem-cache :disk-backed-mem-cache :call-with-cache)
+  (:export :cache :disk-cache :mem-cache :disk-backed-mem-cache :call-with-cache :*cache-dir*
+           :make-disk-backed-mem-cache)
   (:nicknames :cache))
 
 (defpackage orient.lang

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -87,6 +87,11 @@
 	   :*alpha-sort-tuples* :*schema-package*)
   (:nicknames :interface))
 
+(defpackage orient.cache
+  (:use :common-lisp :orient :orient.interface :it.bese.FiveAm :orient.base.util)
+  (:export :cache :disk-cache :mem-cache :disk-backed-mem-cache :call-with-cache)
+  (:nicknames :cache))
+
 (defpackage orient.lang
   (:use :common-lisp :orient :it.bese.FiveAm :orient.base.util :cl-json)
   (:import-from :fset :wb-map :convert)

--- a/base/relation.lisp
+++ b/base/relation.lisp
@@ -75,6 +75,7 @@
   (:method ((tuples list)) (make-relation (convert 'set tuples)))
   (:method ((tuples set))
     (let ((attributes (awhen (arb tuples) (attributes it))))
+      (declare (ignore attributes))
       (make-instance 'simple-relation :tuples tuples))))
 
 (defgeneric cardinality (relation)
@@ -231,20 +232,6 @@
 
   (is (same (set (relation (a b) (1 3) (1 4) (2 3) (2 4)))
             (join (set (relation (a) (1) (2))) (relation (b) (3) (4))))))
-
-
-(defun make-relation-list (spec)
-  (etypecase spec
-    ;; A tuple returns a relation containing it.
-    (wb-map (make-relation (list spec)))
-    ;; A list of all tuples creates a relation from them if they are congruent.
-    ;; Otherwise returns a list of relation-lists, one for element.
-    ((cons wb-map) (or
-		    (and (every (lambda (x) (typep x 'wb-map)) spec)
-			 (make-relation spec))
-		    (convert 'set (mapcar #'make-relation-list spec))))
-    ;; Return a list of relation-lists, one for element of list.
-    (list (convert 'set (mapcar #'make-relation-list spec)))))
 
 (defun make-relation-list (spec)
   (etypecase spec

--- a/cli/cli.lisp
+++ b/cli/cli.lisp
@@ -12,7 +12,7 @@
 
 (defparameter *threadpool-size* 20)
 
-(defparameter *cache* (make-instance 'mem-cache) "Cache to use, if non-NIL.")
+(defparameter *cache* (make-instance 'disk-cache) "Cache to use, if non-NIL.")
 
 (defun keywordize (string-designator)
   (intern (string-upcase (string string-designator)) :keyword))

--- a/cli/cli.lisp
+++ b/cli/cli.lisp
@@ -1,13 +1,18 @@
 (defpackage orient.cli
-  (:use :common-lisp :orient :orient.interface :unix-options :orient.lang :orient.web.html :it.bese.FiveAm :lparallel)
+  (:use :common-lisp :orient :orient.interface :orient.cache :unix-options :orient.lang :orient.web.html :it.bese.FiveAm :lparallel)
   (:shadow :orient :parameter)
   (:nicknames :cli)
   (:export :main))
 
 (in-package :orient.cli)
 
+
 (def-suite orient-cli-suite)
 (in-suite orient-cli-suite)
+
+(defparameter *threadpool-size* 20)
+
+(defparameter *cache* (make-instance 'mem-cache) "Cache to use, if non-NIL.")
 
 (defun keywordize (string-designator)
   (intern (string-upcase (string string-designator)) :keyword))
@@ -31,8 +36,6 @@
 (defun format-error (format-string &rest format-args)
   (apply #'emit-error-output format-args format-args)
   (signal 'error))
-
-(defparameter *threadpool-size* 20)
 
 (defun init ()
   (setf lparallel:*kernel* (lparallel:make-kernel *threadpool-size*)))
@@ -215,7 +218,7 @@
          (terpri *out*))))))
 
 (defun solve-system (&key system vars input override-data)
-  (let ((solution (solve-for system vars input :override-data override-data)))
+  (let ((solution (solve-for system vars input :override-data override-data :cache *cache*)))
     (ensure-tuples solution)))
 
 (defun report-system (&key system vars initial-data override-data)

--- a/orient.asd
+++ b/orient.asd
@@ -15,6 +15,7 @@
 			 (:file "orient")
 			 (:file "constraint")
 			 (:file "interface")
+                         (:file "cache")
 			 (:file "lang")
 			 (:file "presentation"))
 			:perform (test-op (o c) (symbol-call :fiveam :run! (find-symbol "ORIENT-SUITE" "ORIENT"))))

--- a/orient.asd
+++ b/orient.asd
@@ -3,7 +3,7 @@
   :version "0.2.0"
   :author "porcuquine <porcuquine@gmail.com>"
   :licence "MIT"
-  :depends-on ("cl-json" "fiveam" "hunchentoot" "uiop" "unix-options" "fset" "cl-ppcre" "cl-dot" "cl-permutation" "cmu-infix" "dexador" "lparallel")
+  :depends-on ("cl-json" "fiveam" "hunchentoot" "uiop" "unix-options" "fset" "cl-ppcre" "cl-dot" "cl-permutation" "cmu-infix" "dexador" "lparallel" "ironclad")
   :components ((:module "base"
 			:serial t
 			:components


### PR DESCRIPTION
Add CACHE types:
- MEM-CACHE
- DISK-CACHE
- DISK-BACKED-MEM-CACHE

If ORIENT_CACHE_DIR is set, the named directory is used for DISK-BACKED-MEM-CACHE cache files when invoking from CLI (including web option). Otherwise, MEM-CACHE is used.

The cache key depends on both system and input, but does not normalize these for order.

TODO:
- Add option to invoke with no cache.
- Limit size of mem cache.

