### PR TITLE
Improve error handling.

### DIFF
--- a/base/constraint.lisp
+++ b/base/constraint.lisp
@@ -787,7 +787,7 @@
     	      (solve-for system '(n) (tuple (k 4)))))
 
     ;; It is a program error for the INTEGER input to the INTEGER constraint not to be an integer.
-    (signals (type-error) (solve-for system '(n) (tuple (k 4.0))))
+    (signals (pipeline-reduction-error) (solve-for system '(n) (tuple (k 4.0))))
 
     ;; Inconsistent data are not produced. NOTE: Most such constraints yield NIL, but this explicitly produces an empty relation. Normalize?
     (is (same (relation (k n))

--- a/base/packages.lisp
+++ b/base/packages.lisp
@@ -62,6 +62,7 @@
    :org-present :org-present-tuple
    :parameter :parameter-name :parameter-description :parameter-type
    :plan :plan-for :pipeline-signature :private-attr-p :project-commit-link
+   :pipeline-reduction-error
    :present-data :project :publish :prune-system-for-flags
    :range :reduce-range
    :rel :relation :remove-attributes :rename :report-data :report-solution-for :representation :restrict


### PR DESCRIPTION
+ Be more permissive when accepting `extern` input from scripts: all input need not be repeated, but any inconsistent output will be pruned.
+ Wrap any reduction error encountered into `pipeline-reduction-error`, and report it with context of transformation and its input values.